### PR TITLE
Fix dev url issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,8 @@ GEM
     eventmachine (1.2.7)
     ffi (1.16.3)
     forwardable-extended (2.6.0)
+    google-protobuf (4.26.0-arm64-darwin)
+      rake (>= 13)
     google-protobuf (4.26.0-x86_64-linux)
       rake (>= 13)
     http_parser.rb (0.8.0)
@@ -72,6 +74,8 @@ GEM
     mercenary (0.4.0)
     method_source (1.0.0)
     mini_mime (1.1.5)
+    nokogiri (1.16.3-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.3-x86_64-linux)
       racc (~> 1.4)
     pathutil (0.16.2)
@@ -110,6 +114,8 @@ GEM
     rspec-support (3.13.1)
     rubyzip (2.3.2)
     safe_yaml (1.0.5)
+    sass-embedded (1.72.0-arm64-darwin)
+      google-protobuf (>= 3.25, < 5.0)
     sass-embedded (1.72.0-x86_64-linux-gnu)
       google-protobuf (>= 3.25, < 5.0)
     selenium-webdriver (4.18.1)
@@ -126,6 +132,7 @@ GEM
       nokogiri (~> 1.8)
 
 PLATFORMS
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/jekyll-importmap/resolver.rb
+++ b/lib/jekyll-importmap/resolver.rb
@@ -3,35 +3,8 @@ module Jekyll::Importmap
 
     class Resolver
         def self.path_to_asset(path)
-            return path if path.start_with?('http') 
-            self.url + JS_PATH + path
-        end
-
-        def self.host_or_url
-            if Jekyll.configuration['importmap'] && Jekyll.configuration['importmap']['devurl']
-                Jekyll.configuration['importmap']['devurl']
-            else Jekyll.configuration['url']
-                'https://' + Jekyll.configuration['url']
-            end
-        end
-        def self.base_url
-            if Jekyll.configuration['baseurl']
-                Jekyll.configuration['baseurl']
-            else
-                ''
-            end
-        end
-        #def self.port
-            #if Jekyll.configuration['port'] && Jekyll.configuration['port'].length > 0
-                #':' + Jekyll.configuration['port']
-            #else
-                #''
-            #end
-        #end
-
-        def self.url
-            #self.host_or_url + self.port + self.base_url
-            self.host_or_url + self.base_url
+            return path if path.start_with?('http')
+            Jekyll.configuration['baseurl'] + JS_PATH + path
         end
     end
 end


### PR DESCRIPTION
Fixes #1.

We don't actually *need* to specify the full URL to assets hosted locally.

Note: I couldn't get the test suite to run. I'm guessing there's some manual setup?