### PR TITLE
remove excessive calls to Jekyll.config

### DIFF
--- a/lib/jekyll-importmap/resolver.rb
+++ b/lib/jekyll-importmap/resolver.rb
@@ -2,21 +2,25 @@ module Jekyll::Importmap
     JS_PATH = '/'
 
     class Resolver
+        @@configuration = Jekyll.configuration.freeze
+
         def self.path_to_asset(path)
             return path if path.start_with?('http') 
             self.url + JS_PATH + path
         end
 
         def self.host_or_url
-            if Jekyll.configuration['importmap'] && Jekyll.configuration['importmap']['devurl']
-                Jekyll.configuration['importmap']['devurl']
-            else Jekyll.configuration['url']
-                'https://' + Jekyll.configuration['url']
+            if @@configuration['importmap'] && @@configuration['importmap']['devurl']
+
+                @@configuration['importmap']['devurl']
+            else @@configuration['url']
+                'https://' + @@configuration['url']
             end
         end
+
         def self.base_url
-            if Jekyll.configuration['baseurl']
-                Jekyll.configuration['baseurl']
+            if @@configuration['baseurl']
+                @@configuration['baseurl']
             else
                 ''
             end


### PR DESCRIPTION
This plugin washes out the logs with calls to Jekyll.config.

Changing it to a single class variable removes that

Cheers
![Screenshot from 2025-04-18 13-45-08](https://github.com/user-attachments/assets/f23d1b77-8a35-48dd-9b06-e41d1138c72f)
